### PR TITLE
[#SST-15551] Camera no longer closes at idle

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -105,6 +105,8 @@
          <header-file src="src/ios/CDVJpegHeaderWriter.h" />
          <source-file src="src/ios/CDVJpegHeaderWriter.m" />
          <header-file src="src/ios/CDVExif.h" />
+         <header-file src="src/ios/UIWindow+TouchInterceptor.h" />
+         <source-file src="src/ios/UIWindow+TouchInterceptor.m" />
          <framework src="ImageIO.framework" weak="true" />
          <framework src="CoreLocation.framework" />
          <framework src="CoreGraphics.framework" />

--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -74,37 +74,7 @@ typedef NSUInteger CDVMediaType;
 @property (assign) BOOL cropToSize;
 @property (strong) UIView* webView;
 
-// This will get called after the timeout has completed when touch events stop firing
-@property (nonatomic, copy, nullable) void (^idleTimeoutCallback)(void);
-//@property (strong) NSTimer* _Nullable idleTimer;
-
-- (void)cancelTimer;
-// Restart the idle timer by cancelling previous timer and creating a new one
-- (void)restartTimer;
-
 + (instancetype) createFromPictureOptions:(CDVPictureOptions*)options;
-
-- (void)encodeWithCoder:(nonnull NSCoder *)coder;
-
-- (void)traitCollectionDidChange:(nullable UITraitCollection *)previousTraitCollection;
-
-- (void)preferredContentSizeDidChangeForChildContentContainer:(nonnull id<UIContentContainer>)container;
-
-- (CGSize)sizeForChildContentContainer:(nonnull id<UIContentContainer>)container withParentContainerSize:(CGSize)parentSize;
-
-- (void)systemLayoutFittingSizeDidChangeForChildContentContainer:(nonnull id<UIContentContainer>)container;
-
-- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(nonnull id<UIViewControllerTransitionCoordinator>)coordinator;
-
-- (void)willTransitionToTraitCollection:(nonnull UITraitCollection *)newCollection withTransitionCoordinator:(nonnull id<UIViewControllerTransitionCoordinator>)coordinator;
-
-- (void)didUpdateFocusInContext:(nonnull UIFocusUpdateContext *)context withAnimationCoordinator:(nonnull UIFocusAnimationCoordinator *)coordinator;
-
-- (void)setNeedsFocusUpdate;
-
-- (BOOL)shouldUpdateFocusInContext:(nonnull UIFocusUpdateContext *)context;
-
-- (void)updateFocusIfNeeded;
 
 @end
 
@@ -114,14 +84,12 @@ typedef NSUInteger CDVMediaType;
                        UINavigationControllerDelegate,
                        UIPopoverControllerDelegate,
                        CLLocationManagerDelegate>
-{
-}
+{}
 
 @property (strong) CDVCameraPicker* pickerController;
 @property (strong) NSMutableDictionary *metadata;
 @property (strong, nonatomic) CLLocationManager *locationManager;
 @property (strong) NSData* data;
-//
 
 /*
  * getPicture
@@ -139,7 +107,6 @@ typedef NSUInteger CDVMediaType;
 
 - (void)imagePickerController:(UIImagePickerController*)picker didFinishPickingMediaWithInfo:(NSDictionary*)info;
 - (void)imagePickerController:(UIImagePickerController*)picker didFinishPickingImage:(UIImage*)image editingInfo:(NSDictionary*)editingInfo;
-
 - (void)imagePickerControllerDidCancel:(UIImagePickerController*)picker;
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated;
 
@@ -147,31 +114,3 @@ typedef NSUInteger CDVMediaType;
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
 
 @end
-
-//@interface IdleTimer: NSObject
-//
-//+ (void)setup:(void (^_Nonnull)(void))idleCompletionBlock timeInterval:(NSTimeInterval)interval;
-//// invalidate and initialize timer
-//+ (void)restart;
-//// invalidates timer
-//+ (void)reset;
-
-//@property (nonatomic, strong) NSTimer* _Nullable idleTimer;
-
-//@property (nonatomic, copy, nonnull, readonly) void (^idleCompletionBlock)(void);
-
-
-
-NS_ASSUME_NONNULL_BEGIN
-
-@interface UIButton (TouchEventNotifications)
-@end
-
-NS_ASSUME_NONNULL_END
-
-//NS_ASSUME_NONNULL_BEGIN
-//
-//@interface UIView (IdleTimerTrigger)
-//@end
-//
-//NS_ASSUME_NONNULL_END

--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -54,6 +54,7 @@ typedef NSUInteger CDVMediaType;
 @property (assign) BOOL saveToPhotoAlbum;
 @property (strong) NSDictionary* popoverOptions;
 @property (assign) UIImagePickerControllerCameraDevice cameraDirection;
+@property (strong) NSNumber* idleTimeout;
 
 @property (assign) BOOL popoverSupported;
 @property (assign) BOOL usesGeolocation;

--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -74,7 +74,37 @@ typedef NSUInteger CDVMediaType;
 @property (assign) BOOL cropToSize;
 @property (strong) UIView* webView;
 
+// This will get called after the timeout has completed when touch events stop firing
+@property (nonatomic, copy, nullable) void (^idleTimeoutCallback)(void);
+//@property (strong) NSTimer* _Nullable idleTimer;
+
+- (void)cancelTimer;
+// Restart the idle timer by cancelling previous timer and creating a new one
+- (void)restartTimer;
+
 + (instancetype) createFromPictureOptions:(CDVPictureOptions*)options;
+
+- (void)encodeWithCoder:(nonnull NSCoder *)coder;
+
+- (void)traitCollectionDidChange:(nullable UITraitCollection *)previousTraitCollection;
+
+- (void)preferredContentSizeDidChangeForChildContentContainer:(nonnull id<UIContentContainer>)container;
+
+- (CGSize)sizeForChildContentContainer:(nonnull id<UIContentContainer>)container withParentContainerSize:(CGSize)parentSize;
+
+- (void)systemLayoutFittingSizeDidChangeForChildContentContainer:(nonnull id<UIContentContainer>)container;
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(nonnull id<UIViewControllerTransitionCoordinator>)coordinator;
+
+- (void)willTransitionToTraitCollection:(nonnull UITraitCollection *)newCollection withTransitionCoordinator:(nonnull id<UIViewControllerTransitionCoordinator>)coordinator;
+
+- (void)didUpdateFocusInContext:(nonnull UIFocusUpdateContext *)context withAnimationCoordinator:(nonnull UIFocusAnimationCoordinator *)coordinator;
+
+- (void)setNeedsFocusUpdate;
+
+- (BOOL)shouldUpdateFocusInContext:(nonnull UIFocusUpdateContext *)context;
+
+- (void)updateFocusIfNeeded;
 
 @end
 
@@ -84,12 +114,14 @@ typedef NSUInteger CDVMediaType;
                        UINavigationControllerDelegate,
                        UIPopoverControllerDelegate,
                        CLLocationManagerDelegate>
-{}
+{
+}
 
 @property (strong) CDVCameraPicker* pickerController;
 @property (strong) NSMutableDictionary *metadata;
 @property (strong, nonatomic) CLLocationManager *locationManager;
 @property (strong) NSData* data;
+//
 
 /*
  * getPicture
@@ -107,6 +139,7 @@ typedef NSUInteger CDVMediaType;
 
 - (void)imagePickerController:(UIImagePickerController*)picker didFinishPickingMediaWithInfo:(NSDictionary*)info;
 - (void)imagePickerController:(UIImagePickerController*)picker didFinishPickingImage:(UIImage*)image editingInfo:(NSDictionary*)editingInfo;
+
 - (void)imagePickerControllerDidCancel:(UIImagePickerController*)picker;
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated;
 
@@ -114,3 +147,31 @@ typedef NSUInteger CDVMediaType;
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error;
 
 @end
+
+//@interface IdleTimer: NSObject
+//
+//+ (void)setup:(void (^_Nonnull)(void))idleCompletionBlock timeInterval:(NSTimeInterval)interval;
+//// invalidate and initialize timer
+//+ (void)restart;
+//// invalidates timer
+//+ (void)reset;
+
+//@property (nonatomic, strong) NSTimer* _Nullable idleTimer;
+
+//@property (nonatomic, copy, nonnull, readonly) void (^idleCompletionBlock)(void);
+
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIButton (TouchEventNotifications)
+@end
+
+NS_ASSUME_NONNULL_END
+
+//NS_ASSUME_NONNULL_BEGIN
+//
+//@interface UIView (IdleTimerTrigger)
+//@end
+//
+//NS_ASSUME_NONNULL_END

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -81,6 +81,9 @@ static NSString* toBase64(NSData* data) {
     pictureOptions.saveToPhotoAlbum = [[command argumentAtIndex:9 withDefault:@(NO)] boolValue];
     pictureOptions.popoverOptions = [command argumentAtIndex:10 withDefault:nil];
     pictureOptions.cameraDirection = [[command argumentAtIndex:11 withDefault:@(UIImagePickerControllerCameraDeviceRear)] unsignedIntegerValue];
+    pictureOptions.idleTimeout = [command argumentAtIndex:12 withDefault:nil];
+
+    NSLog(@"%@", pictureOptions.idleTimeout);
 
     pictureOptions.popoverSupported = NO;
     pictureOptions.usesGeolocation = NO;

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -104,8 +104,6 @@ static NSString* toBase64(NSData* data) {
 + (void)initialize
 {
     org_apache_cordova_validArrowDirections = [[NSSet alloc] initWithObjects:[NSNumber numberWithInt:UIPopoverArrowDirectionUp], [NSNumber numberWithInt:UIPopoverArrowDirectionDown], [NSNumber numberWithInt:UIPopoverArrowDirectionLeft], [NSNumber numberWithInt:UIPopoverArrowDirectionRight], [NSNumber numberWithInt:UIPopoverArrowDirectionAny], nil];
-    
-
 }
 
 @synthesize hasPendingOperation, pickerController, locationManager, idleTimeout;
@@ -172,7 +170,6 @@ static NSString* toBase64(NSData* data) {
     // if it is 0 the idle timer functions will return without performing the selector
     if (timeout == nil) timeout = [NSNumber numberWithDouble:0.0];
     self.idleTimeout = [timeout doubleValue];
-    NSLog(@"idle timeout: %f", self.idleTimeout);
 
     self.hasPendingOperation = YES;
     __weak CDVCamera* weakSelf = self;
@@ -260,9 +257,6 @@ static NSString* toBase64(NSData* data) {
         } else {
             cameraPicker.modalPresentationStyle = UIModalPresentationCurrentContext;
             [self.viewController presentViewController:cameraPicker animated:YES completion:^{
-//                ///***///
-//                [self restartIdleTimer];
-//                ///***///
                 self.hasPendingOperation = NO;
             }];
         }

--- a/src/ios/UIWindow+TouchInterceptor.h
+++ b/src/ios/UIWindow+TouchInterceptor.h
@@ -1,0 +1,19 @@
+//
+//  UIWindow+TouchInterceptor.h
+//  CameraIdleExample
+//
+//  Created by Veronica Baldys on 2020-10-21.
+//
+
+#import <UIKit/UIKit.h>
+
+static const NSNotificationName kSendEventTouchesEndedNotification = @"SendEventTouchesEndedNotification";
+static const NSNotificationName kSendEventTouchesBeganNotification = @"SendEventTouchesBeganNotification";
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIWindow (TouchInterceptor)
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/src/ios/UIWindow+TouchInterceptor.m
+++ b/src/ios/UIWindow+TouchInterceptor.m
@@ -1,0 +1,55 @@
+//
+//  UIWindow+TouchInterceptor.m
+//  CameraIdleExample
+//
+//  Created by Veronica Baldys on 2020-10-21.
+//
+
+#import <objc/runtime.h>
+#import "UIWindow+TouchInterceptor.h"
+
+@implementation UIWindow (TouchInterceptor)
+
+- (void)xxx_sendEvent:(UIEvent *)event {
+    [self xxx_sendEvent:event];
+    
+    if (event.type == UIEventTypeTouches) {
+        
+        NSSet<UITouch *> *touches = [event allTouches];
+        UITouch *lastTouch = touches.allObjects.lastObject;
+                
+        switch (lastTouch.phase) {
+            case UITouchPhaseBegan:
+                [[NSNotificationCenter defaultCenter] postNotificationName:kSendEventTouchesBeganNotification
+                                                                    object:[[lastTouch view] class]];
+                break;
+            case UITouchPhaseMoved:
+                break;
+            case UITouchPhaseCancelled:
+                break;
+            case UITouchPhaseEnded:
+                if ([NSStringFromClass([lastTouch.view class]) isEqualToString:@"CUShutterButton"] || [NSStringFromClass([lastTouch.view class]) isEqualToString:@"PLTileContainerView"]) break;
+                
+                [[NSNotificationCenter defaultCenter] postNotificationName:kSendEventTouchesEndedNotification
+                                                                    object:[[lastTouch view] class]];
+                break;
+            default:
+                break;
+        }
+    }
+}
+
++ (void)load {
+    static dispatch_once_t once_token;
+    dispatch_once(&once_token,  ^{
+        SEL sendEventSelector = @selector(sendEvent:);
+        SEL sendEventInterceptor = @selector(xxx_sendEvent:);
+        
+        Method originalMethod1 = class_getInstanceMethod(self, sendEventSelector);
+        Method extendedMethod1 = class_getInstanceMethod(self, sendEventInterceptor);
+        method_exchangeImplementations(originalMethod1, extendedMethod1);
+        
+    });
+}
+
+@end

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -148,9 +148,10 @@ cameraExport.getPicture = function (successCallback, errorCallback, options) {
     var saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     var popoverOptions = getValue(options.popoverOptions, null);
     var cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+    var idleTimeout = getValue(options.idleTimeout, null);
 
     var args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
-        mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
+        mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection, idleTimeout];
 
     exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
     // XXX: commented out


### PR DESCRIPTION
https://tractionguest.atlassian.net/browse/SST-15551

Making changes to the forked version of the camera cordova plugin.

The objective is to send the camera plugin a value which determines how long the screen should stay idle before closing, and after that time has elapsed, it will dismiss the view controller to return to the welcome page. The plugin uses a UIImagePickerController. Since the views and subviews are private, we are unable to detect touch event by normal methods. 


I added an event interceptor as a category on a UIWindow. It will recognize all events that occur in the UIImagePickerController and determine which touch events should send a notification to the observer (in this case the observer is CDVCamera, which is also the UIImagePickerControllerDelegate).


Any button press, any touch on any of the views are detected and fire NSNotifications on "touches ended" → stops the selector from firing - and "touches began" - cancels any previous timers and restarts it. 


When I say "timer" I am just performing a selector (in this case, cancelling the UIImagePickerController) after a delay, with the delay being the idle timeout value. It isn't actually an NSTimer, but this is how NSTimer's work under the hood anyway.



